### PR TITLE
Update ZHllqq5CFit.cc

### DIFF
--- a/src/ZHllqq5CFit.cc
+++ b/src/ZHllqq5CFit.cc
@@ -334,7 +334,7 @@ void ZHllqq5CFit::processEvent( LCEvent * evt ) { //event start
       
       // use simple parametrisation or jet covariances?
       if (_errene > 0) {
-        JetResE    = _errene;
+        JetResE    = _errene * std::sqrt(jetvec.e());
         JetResTheta=_errtheta;
         JetResPhi=_errphi;
       }


### PR DESCRIPTION
Bug fix:
JetResE    = _errene;  ->  JetResE    = _errene * std::sqrt(jetvec.e());

(_errene is the "x" in sigma_E/E = x/sqrt(E)", thus the absolute error on E is  _errene * sqrt(E) )



BEGINRELEASENOTES
- bug fix in ZHllqq5CFit for usage of fixed JER 

ENDRELEASENOTES