### PR TITLE
Make doxygen cmake config work with newer cmakes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
+          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DINSTALL_DOC=ON ..
           ninja -k0
           ctest --output-on-failure
           ninja install

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -15,6 +15,8 @@ IF( DOXYGEN_FOUND )
     # directories to search for documentation
     SET( DOX_INPUT ./kinfit.doxygen ../include ../src )
 
+    FILE(GLOB DOXYGEN_SOURCES ../include/* ../src/*)
+
     # custom command to build documentation
     ADD_CUSTOM_COMMAND(
         OUTPUT  "${DOC_BIN_DIR}/html/index.html"
@@ -25,7 +27,7 @@ IF( DOXYGEN_FOUND )
                 "${DOXYGEN_EXECUTABLE}"
         WORKING_DIRECTORY "${DOC_SRC_DIR}"
         COMMENT "Building API Documentation..."
-        DEPENDS Doxyfile kinfit.doxygen CMakeLists.txt ../include/* ../src/*
+        DEPENDS Doxyfile kinfit.doxygen CMakeLists.txt ${DOXYGEN_SOURCES}
     )
 
     # add doc target


### PR DESCRIPTION

BEGINRELEASENOTES
- Make doxygen cmake config work with newer cmakes (>= 3.17)

ENDRELEASENOTES